### PR TITLE
Fix pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Stop stopwatch.
 
 #### `stopwatch-pause`
 
-Pause stopwatch.
+Toggle (pause/resume) stopwatch.
 
 #### `stopwatch-restart`
 
-Restart stopwatch which is paused by `stopwatch-pause`.
+Restart stopwatch counter to begin from 0.
 
 ## Desktop Notification
 

--- a/stopwatch.el
+++ b/stopwatch.el
@@ -128,13 +128,18 @@
 
 (defun stopwatch-restart ()
   (interactive)
-  (setq current-state 'working)
-  (setq stopwatch--timer (run-with-timer 0 1 'stopwatch-timer--tick)))
+  (stopwatch-stop)
+  (stopwatch-start))
 
 (defun stopwatch-pause ()
   (interactive)
-  (setq current-state 'pausing)
-  (cancel-timer stopwatch--timer))
+  (if (eq current-state 'pausing)
+      (progn
+        (setq current-state 'working)
+        (setq stopwatch--timer (run-with-timer 0 1 'stopwatch-timer--tick)))
+    (progn
+      (setq current-state 'pausing)
+      (cancel-timer stopwatch--timer))))
 
 (unless (member '(:eval (stopwatch--propertize-mode-line)) mode-line-format)
   (setq-default mode-line-format


### PR DESCRIPTION
When I use restart without pause before the timer' ticks goes wrong.

stopwatch-pause: pause or resume timer 
stopwatch-restart: restart the timer to 0